### PR TITLE
Delete unused Integer i in function getlibname

### DIFF
--- a/amx/amx.c
+++ b/amx/amx.c
@@ -1102,7 +1102,6 @@ static int VerifyPcode(AMX *amx)
 
   static void getlibname(char *libname,const char *source)
   {
-    int i;
     #if defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
       char *root=getenv("AMXLIB");
     #endif


### PR DESCRIPTION
The getlibname function has an int i declared that is never used within the function.