### PR TITLE
Correct typo in function amx_Cleanup hlob --> hlib

### DIFF
--- a/amx/amx.c
+++ b/amx/amx.c
@@ -1496,7 +1496,7 @@ int AMXAPI amx_Cleanup(AMX *amx)
           if (libcleanup!=NULL)
             libcleanup(amx);
           #if defined _Windows
-            FreeLibrary(hlob);
+            FreeLibrary(hlib);
           #elif defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
             dlclose(hlib);
           #endif


### PR DESCRIPTION
A typo in the amx_Cleanup function causes windows builds to fail:  hlob --> hlib